### PR TITLE
chore: Add GMSPlaceField+SetAlgebra extension.

### DIFF
--- a/GooglePlaces-Swift/GooglePlacesSwiftDemo.xcodeproj/project.pbxproj
+++ b/GooglePlaces-Swift/GooglePlacesSwiftDemo.xcodeproj/project.pbxproj
@@ -3,11 +3,12 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
 		5136D7B61AE24EB0CC89EEB2 /* libPods-GooglePlacesSwiftDemo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 855FD784CB8414A4C8189817 /* libPods-GooglePlacesSwiftDemo.a */; };
+		AAA7D63C24E30F5400C202B2 /* GMSPlaceFIeld+SetAlgebra.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAA7D63B24E30F5400C202B2 /* GMSPlaceFIeld+SetAlgebra.swift */; };
 		E1938165249A95A700C4A49A /* SampleListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1938163249A95A700C4A49A /* SampleListViewController.swift */; };
 		E1938166249A95A700C4A49A /* SampleDatas.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1938164249A95A700C4A49A /* SampleDatas.swift */; };
 		E1938171249A966900C4A49A /* PagingPhotoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1938169249A966900C4A49A /* PagingPhotoView.swift */; };
@@ -28,6 +29,7 @@
 		855FD784CB8414A4C8189817 /* libPods-GooglePlacesSwiftDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-GooglePlacesSwiftDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		8C4B507A720A283D6EAFE884 /* Pods-GooglePlacesSwiftDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GooglePlacesSwiftDemo.debug.xcconfig"; path = "Target Support Files/Pods-GooglePlacesSwiftDemo/Pods-GooglePlacesSwiftDemo.debug.xcconfig"; sourceTree = "<group>"; };
 		A53C462A918EEDA78352B704 /* Pods-GooglePlacesSwiftDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GooglePlacesSwiftDemo.release.xcconfig"; path = "Target Support Files/Pods-GooglePlacesSwiftDemo/Pods-GooglePlacesSwiftDemo.release.xcconfig"; sourceTree = "<group>"; };
+		AAA7D63B24E30F5400C202B2 /* GMSPlaceFIeld+SetAlgebra.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GMSPlaceFIeld+SetAlgebra.swift"; sourceTree = "<group>"; };
 		E1938163249A95A700C4A49A /* SampleListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SampleListViewController.swift; sourceTree = "<group>"; };
 		E1938164249A95A700C4A49A /* SampleDatas.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SampleDatas.swift; sourceTree = "<group>"; };
 		E1938169249A966900C4A49A /* PagingPhotoView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PagingPhotoView.swift; sourceTree = "<group>"; };
@@ -72,7 +74,6 @@
 				8C4B507A720A283D6EAFE884 /* Pods-GooglePlacesSwiftDemo.debug.xcconfig */,
 				A53C462A918EEDA78352B704 /* Pods-GooglePlacesSwiftDemo.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -128,14 +129,15 @@
 		E1FA42562463335A00E0C1B9 /* GooglePlacesSwiftDemo */ = {
 			isa = PBXGroup;
 			children = (
-				E193817B249A96CC00C4A49A /* Resources */,
-				E1938167249A95F600C4A49A /* Samples */,
+				E1FA42652463335B00E0C1B9 /* Info.plist */,
 				E1FA42572463335A00E0C1B9 /* AppDelegate.swift */,
-				E1FA426B24633B2000E0C1B9 /* SDKDemoAPIKey.swift */,
+				AAA7D63B24E30F5400C202B2 /* GMSPlaceFIeld+SetAlgebra.swift */,
 				E1938164249A95A700C4A49A /* SampleDatas.swift */,
 				E1938163249A95A700C4A49A /* SampleListViewController.swift */,
+				E1FA426B24633B2000E0C1B9 /* SDKDemoAPIKey.swift */,
 				E1FA42602463335B00E0C1B9 /* Assets.xcassets */,
-				E1FA42652463335B00E0C1B9 /* Info.plist */,
+				E193817B249A96CC00C4A49A /* Resources */,
+				E1938167249A95F600C4A49A /* Samples */,
 			);
 			path = GooglePlacesSwiftDemo;
 			sourceTree = "<group>";
@@ -236,18 +238,11 @@
 			files = (
 			);
 			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-GooglePlacesSwiftDemo/Pods-GooglePlacesSwiftDemo-resources.sh",
-				"${PODS_ROOT}/GoogleMaps/Maps/Frameworks/GoogleMaps.framework/Resources/GoogleMaps.bundle",
-				"${PODS_ROOT}/GooglePlaces/Frameworks/GooglePlaces.framework/Resources/GooglePlaces.bundle",
+				"${PODS_ROOT}/Target Support Files/Pods-GooglePlacesSwiftDemo/Pods-GooglePlacesSwiftDemo-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
-			);
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleMaps.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GooglePlaces.bundle",
+				"${PODS_ROOT}/Target Support Files/Pods-GooglePlacesSwiftDemo/Pods-GooglePlacesSwiftDemo-resources-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -270,6 +265,7 @@
 				E1938175249A966900C4A49A /* AutocompleteWithCustomColors.swift in Sources */,
 				E1FA426C24633B2000E0C1B9 /* SDKDemoAPIKey.swift in Sources */,
 				E1938166249A95A700C4A49A /* SampleDatas.swift in Sources */,
+				AAA7D63C24E30F5400C202B2 /* GMSPlaceFIeld+SetAlgebra.swift in Sources */,
 				E1938174249A966900C4A49A /* AutocompleteWithTextFieldController.swift in Sources */,
 				E1938178249A966900C4A49A /* AutocompleteWithSearchViewController.swift in Sources */,
 				E193817A249A967B00C4A49A /* FindPlaceLikelihoodListViewController.swift in Sources */,

--- a/GooglePlaces-Swift/GooglePlacesSwiftDemo/GMSPlaceFIeld+SetAlgebra.swift
+++ b/GooglePlaces-Swift/GooglePlacesSwiftDemo/GMSPlaceFIeld+SetAlgebra.swift
@@ -1,0 +1,92 @@
+// Copyright 2020 Google LLC. All rights reserved.
+//
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+// file except in compliance with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+// ANY KIND, either express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+import GooglePlaces
+
+/**
+  This extension is used as a workaround to enable using GMSPlaceField as if it were an NS_OPTIONS. Doing so
+ enables set notation usage to combine multiple GMSPlaceFields.
+ 
+ e.g. let fiels: GMSPlaceField = [.name, .phoneNumber]
+ */
+extension GMSPlaceField : SetAlgebra {
+    public init() {
+        self.init(rawValue: 0)!
+    }
+    
+    public func contains(_ member: GMSPlaceField) -> Bool {
+        return self.isSuperset(of: member)
+    }
+    
+    public __consuming func union(_ other: __owned GMSPlaceField) -> GMSPlaceField {
+        var returnValue = GMSPlaceField(rawValue: self.rawValue)!
+        returnValue.formUnion(other)
+        return returnValue
+    }
+    
+    public __consuming func intersection(_ other: GMSPlaceField) -> GMSPlaceField {
+        var returnValue = GMSPlaceField(rawValue: self.rawValue)!
+        returnValue.formIntersection(other)
+        return returnValue
+    }
+    
+    public __consuming func symmetricDifference(_ other: __owned GMSPlaceField) -> GMSPlaceField {
+        var returnValue = GMSPlaceField(rawValue: self.rawValue)!
+        returnValue.formSymmetricDifference(other)
+        return returnValue
+    }
+    
+    public mutating func insert(_ newMember: __owned GMSPlaceField) -> (inserted: Bool, memberAfterInsert: GMSPlaceField) {
+        let oldMember = self.intersection(newMember)
+        let shouldInsert = oldMember != newMember
+        let result = (
+          inserted: shouldInsert,
+          memberAfterInsert: shouldInsert ? newMember : oldMember)
+        if shouldInsert {
+          self.formUnion(newMember)
+        }
+        return result
+    }
+    
+    public mutating func remove(_ member: GMSPlaceField) -> GMSPlaceField? {
+        let intersectionElements = intersection(member)
+        guard !intersectionElements.isEmpty else {
+          return nil
+        }
+        
+        self.subtract(member)
+        return intersectionElements
+    }
+    
+    public mutating func update(with newMember: __owned GMSPlaceField) -> GMSPlaceField? {
+        let r = self.intersection(newMember)
+        self.formUnion(newMember)
+        return r.isEmpty ? nil : r
+    }
+    
+    public mutating func formUnion(_ other: __owned GMSPlaceField) {
+        self = GMSPlaceField(rawValue: self.rawValue | other.rawValue)!
+    }
+    
+    public mutating func formIntersection(_ other: GMSPlaceField) {
+        self = GMSPlaceField(rawValue: self.rawValue & other.rawValue)!
+    }
+    
+    public mutating func formSymmetricDifference(_ other: __owned GMSPlaceField) {
+        self = GMSPlaceField(rawValue: self.rawValue ^ other.rawValue)!
+    }
+    
+    public typealias Element = GMSPlaceField
+    
+    public typealias ArrayLiteralElement = GMSPlaceField
+}

--- a/GooglePlaces-Swift/GooglePlacesSwiftDemo/Samples/FindPlaceLikelihoodListViewController.swift
+++ b/GooglePlaces-Swift/GooglePlacesSwiftDemo/Samples/FindPlaceLikelihoodListViewController.swift
@@ -92,7 +92,11 @@ class FindPlaceLikelihoodListViewController: UIViewController {
     }
     locationManager.startUpdatingLocation()
 
-    placeClient.findPlaceLikelihoodsFromCurrentLocation(withPlaceFields: .all) {
+    // Note: The OptionSet syntax below is enabled by the GMSPlaceField+SetAlgebra extension.
+    // See: GMSPlaceField+SetAlgebra.swift
+    let placeFields: GMSPlaceField = [.name, .placeID]
+    
+    placeClient.findPlaceLikelihoodsFromCurrentLocation(withPlaceFields: placeFields) {
       [weak self] (list, error) -> Void in
       guard let strongSelf = self else { return }
       guard error == nil else {


### PR DESCRIPTION
Currently, combining GMSPlaceField objects is done using the rawValue initializer of GMSPlaceField. Since this returns an optional, unwrapping is required:

e.g.

```swift
let placeFields: GMSPlaceField = GMSPlaceField(
    rawValue: GMSPlaceField.placeId.rawValue | GMSPlaceField.name.rawValue
)!
```

The extension found within `GMSPlaceField+SetAlgebra.swift` enables OptionSet syntax such that a non-optional is returned and multiple GMSPlaceFields can be combined with an array literal.

i.e.

```swift
let placeFields: GMSPlaceField = [.placeId, .name]
```

