### PR TITLE
fix: Tiny bug fix regarding action menu color when switching from independent to multiple features

### DIFF
--- a/MapsAndPlacesDemo/MapsAndPlacesDemo/MainViewController.swift
+++ b/MapsAndPlacesDemo/MapsAndPlacesDemo/MainViewController.swift
@@ -275,6 +275,7 @@ class GoogleDemoApplicationsMainViewController:
         for a in actions {
             actionSheet.addAction(a as! MDCActionSheetAction)
         }
+        refreshScreen()
     }
     
     /// Requests the user's location


### PR DESCRIPTION
### Overview
When the screen is in dark mode and independent features, there needs to be a screen refresh when you turn on/off independent features. Before, when dark mode was on and you wanted to turn off independent features, the action menu would turn white even though you haven't turned off dark mode yet (see image).
#### Fix
The fix was to simply refresh the screen whenever the action menu is refreshed so the color schemes are accurate (only one line of code added).

Thanks!

<img width="508" alt="Screen Shot 2020-08-19 at 5 00 04 PM" src="https://user-images.githubusercontent.com/35410477/90689937-d190d100-e23e-11ea-9fda-27f764fd2d98.png">

