### PR TITLE
chore: fix ruby setup in pod try sync

### DIFF
--- a/.github/workflows/pod_try_sync.yml
+++ b/.github/workflows/pod_try_sync.yml
@@ -24,12 +24,19 @@ on:
 jobs:
   check_pod_try:
     # The type of runner that the job will run on
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout maps-sdk-for-ios-samples
       uses: actions/checkout@v2
+
+    # Set up Ruby
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.7' # pod try breaks with Ruby 3.0
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
     # Install CocoaPods v 1.6.1. Need to use this version since there are issues with running `pod try` on later versions
     - name: Install CocoaPods 1.6.1
@@ -44,26 +51,17 @@ jobs:
 
     # Copy pod try GoogleMaps Objective-C to current copy
     - name: Copy pod try GoogleMaps Objective-C changes into current copy
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: '2.7.6' # pod try breaks with Ruby 3.0
       run: |
         $GITHUB_WORKSPACE/copy_pod_try.sh GoogleMaps $GITHUB_WORKSPACE/GoogleMaps 1
 
     # Copy pod try GoogleMaps Swift to current copy
     - name: Copy pod try GoogleMaps Swift changes into current copy
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: '2.7.6' # pod try breaks with Ruby 3.0
       run: |
         mkdir -p $GITHUB_WORKSPACE/GoogleMaps-Swift
         $GITHUB_WORKSPACE/copy_pod_try.sh GoogleMaps $GITHUB_WORKSPACE/GoogleMaps-Swift 2
 
     # Copy pod try GooglePlaces Objective-C to current copy
     - name: Copy pod try GooglePlaces Objective-C changes into current copy
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: '2.7.6' # pod try breaks with Ruby 3.0
       run: |
         mkdir -p $GITHUB_WORKSPACE/GooglePlaces-Swift
         $GITHUB_WORKSPACE/copy_pod_try.sh GooglePlaces $GITHUB_WORKSPACE/GooglePlaces 1
@@ -71,9 +69,6 @@ jobs:
     # Copy pod try GooglePlaces Swift to current copy
     - name: Copy pod try GooglePlaces Swift changes into current copy
       id: pod_try_copy
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: '2.7.6' # pod try breaks with Ruby 3.0
       run: |
         mkdir -p $GITHUB_WORKSPACE/GooglePlaces-Swift
         $GITHUB_WORKSPACE/copy_pod_try.sh GooglePlaces $GITHUB_WORKSPACE/GooglePlaces-Swift 2


### PR DESCRIPTION
* Pin MacOS runner image to 11 until ruby setup is verified
* Move ruby setup to job-level setup instead of step-level
