### PR TITLE
chore: Update platform target to iOS 13

### DIFF
--- a/tutorials/current-place-on-map/Podfile
+++ b/tutorials/current-place-on-map/Podfile
@@ -1,6 +1,6 @@
 source 'https://github.com/CocoaPods/Specs.git'
 target 'current-place-on-map' do
   platform :ios, '13.0'
-  pod 'GooglePlaces'
-  pod 'GoogleMaps'
+  pod 'GoogleMaps', '7.3.0'
+  pod 'GooglePlaces', '7.3.0'
 end

--- a/tutorials/current-place-on-map/Podfile
+++ b/tutorials/current-place-on-map/Podfile
@@ -1,6 +1,6 @@
 source 'https://github.com/CocoaPods/Specs.git'
 target 'current-place-on-map' do
-  platform :ios, '12.0'
+  platform :ios, '13.0'
   pod 'GooglePlaces'
   pod 'GoogleMaps'
 end

--- a/tutorials/map-with-marker/Podfile
+++ b/tutorials/map-with-marker/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
 target 'map-with-marker' do
   platform :ios, '13.0'
-  pod 'GoogleMaps'
+  pod 'GoogleMaps', '7.3.0'
 end

--- a/tutorials/map-with-marker/Podfile
+++ b/tutorials/map-with-marker/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
 target 'map-with-marker' do
-  platform :ios, '12.0'
+  platform :ios, '13.0'
   pod 'GoogleMaps'
 end

--- a/tutorials/places-address-form/Podfile
+++ b/tutorials/places-address-form/Podfile
@@ -1,5 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
-  target 'places-address-form' do
+target 'places-address-form' do
   platform :ios, '13.0'
-  pod 'GooglePlaces'
+  pod 'GooglePlaces', '7.3.0'
 end

--- a/tutorials/places-address-form/Podfile
+++ b/tutorials/places-address-form/Podfile
@@ -1,4 +1,5 @@
 source 'https://github.com/CocoaPods/Specs.git'
   target 'places-address-form' do
+  platform :ios, '13.0'
   pod 'GooglePlaces'
 end


### PR DESCRIPTION
---
name: Update platform target to iOS 13
---
Base support for the Maps and Places SDK's is now iOS 13. Users that run **pod install** or **pod update** with these changes will receive the latest minor pod version. 