### PR TITLE
chore: new examples for sprite polylines

### DIFF
--- a/snippets/MapsSnippets/MapsSnippets/Shapes.m
+++ b/snippets/MapsSnippets/MapsSnippets/Shapes.m
@@ -171,4 +171,65 @@ GMSMapView *mapView;
   // [END maps_ios_shapes_circles_customize]
 }
 
+- (void)spritePolyLine {
+  // [START maps_ios_polyline_sprite]
+  GMSMutablePath *path = [GMSMutablePath path];
+  [path addLatitude:-37.81319 longitude:144.96298];
+  [path addLatitude:-31.95285 longitude:115.85734];
+  polyline.strokeWidth = 20;
+  GMSPolyline *polyline = [GMSPolyline polylineWithPath:path];
+
+  UIImage *image = [UIImage imageNamed:@"imageFromBundleOrAsset"];
+  GMSStrokeStyle *transparentStampStroke = [GMSStrokeStyle transparentStrokeWithStampStyle:[GMSSpriteStyle spriteStyleWithImage:image]];
+
+  GMSStyleSpan *span = [GMSStyleSpan spanWithStyle:transparentStampStroke];
+  polyline.spans = @[span];
+  polyline.map = _mapView;
+  // [END maps_ios_polyline_sprite]
+}
+
+- (void)texturePolyline {
+  // [START maps_ios_polyline_texture]
+  GMSMutablePath *path = [GMSMutablePath path];
+  [path addLatitude:-37.81319 longitude:144.96298];
+  [path addLatitude:-31.95285 longitude:115.85734];
+  GMSPolyline *polyline = [GMSPolyline polylineWithPath:path];
+  polyline.strokeWidth = 20;
+  GMSStrokeStyle *redWithStamp = [GMSStrokeStyle solidColor:[UIColor redColor]];
+
+  UIImage *image = [UIImage imageNamed:@"imageFromBundleOrAsset"]; // Image could be from anywhere
+  redWithStamp.stampStyle = [GMSTextureStyle textureStyleWithImage:image];
+
+  GMSStyleSpan *span = [GMSStyleSpan spanWithStyle:redWithStamp];
+  polyline.spans = @[span];
+  polyline.map = _mapView;
+  // [END maps_ios_polyline_texture]
+}
+
+- (void)mapCapabilties {
+  // [START maps_ios_map_capabilities]
+  GMSMutablePath *path = [GMSMutablePath path];
+  [path addLatitude:-37.81319 longitude:144.96298];
+  [path addLatitude:-31.95285 longitude:115.85734];
+
+  UIImage *_Nonnull image = [UIImage imageNamed:@"imageFromBundleOrAsset"]; // Image could be from anywhere
+
+  NSArray<GMSStyleSpan *> * spans;
+  if (_mapView.mapCapabilities & GMSMapCapabilityFlagsSpritePolylines) {
+    GMSSpriteStyle *spriteStyle = [GMSSpriteStyle spriteStyleWithImage:image];
+    GMSStrokeStyle *stroke = [GMSStrokeStyle transparentStrokeWithStampStyle:spriteStyle];
+    spans = @[ [GMSStyleSpan spanWithStyle:stroke] ];
+  } else {
+    GMSStrokeStyle *stroke = [GMSStrokeStyle solidColor:UIColor.clearColor];
+    stroke.stampStyle = [GMSTextureStyle textureStyleWithImage:image];
+    spans = @[ [GMSStyleSpan spanWithStyle:stroke] ];
+  }
+
+  GMSPolyline *polyline = [GMSPolyline polylineWithPath:path];
+  polyline.strokeWidth = 20;
+  polyline.spans = spans;
+  polyline.map = _mapView;
+  // [END maps_ios_map_capabilities]
+}
+
 @end

--- a/snippets/MapsSnippets/MapsSnippets/Swift/Shapes.swift
+++ b/snippets/MapsSnippets/MapsSnippets/Swift/Shapes.swift
@@ -178,4 +178,59 @@ class Shapes {
     circle.strokeWidth = 5
     // [END maps_ios_shapes_circles_customize]
   }
+
+  func spritePolyline() {
+      // [START maps_ios_polyline_sprite]
+      let path = GMSMutablePath()
+      path.addLatitude(-37.81319, longitude: 144.96298)
+      path.addLatitude(-31.95285, longitude: 115.85734)
+      let polyline = GMSPolyline(path: path)
+      polyline.strokeWidth = 20
+      let image = UIImage(named: "imageFromBundleOrAsset")! // Image could be from anywhere
+      let stampStyle = GMSSpriteStyle(image: image)
+      let transparentStampStroke = GMSStrokeStyle.transparentStroke(withStamp: stampStyle)
+      let span = GMSStyleSpan(style: transparentStampStroke)
+      polyline.spans = [span]
+      polyline.map = mapView
+      // [END maps_ios_polyline_sprite]
+    }
+
+    func texturePolyline() {
+      // [START maps_ios_polyline_texture]
+      let path = GMSMutablePath()
+      path.addLatitude(-37.81319, longitude: 144.96298)
+      path.addLatitude(-31.95285, longitude: 115.85734)
+      let polyline = GMSPolyline(path: path)
+      polyline.strokeWidth = 20
+      let redWithStamp = GMSStrokeStyle.solidColor(.red)
+      let image = UIImage(named: "imageFromBundleOrAsset")! // Image could be from anywhere
+      redWithStamp.stampStyle = GMSTextureStyle(image: image)
+      let span = GMSStyleSpan(style: redWithStamp)
+      polyline.spans = [span]
+      polyline.map = mapView
+      // [END maps_ios_polyline_texture]
+    }
+
+    func mapCapabilities() {
+      // [START maps_ios_map_capabilities]
+      let path = GMSMutablePath()
+      path.addLatitude(-37.81319, longitude: 144.96298)
+      path.addLatitude(-31.95285, longitude: 115.85734)
+      let polyline = GMSPolyline(path: path)
+      polyline.strokeWidth = 20
+      let image = UIImage(named: "imageFromBundleOrAsset")! // Image could be from anywhere
+      let spans: [GMSStyleSpan]
+      if (mapView.mapCapabilities.contains(.spritePolylines)) {
+        let spriteStyle = GMSSpriteStyle(image: image)
+        let stroke = GMSStrokeStyle.transparentStroke(withStamp: spriteStyle)
+        spans = [ GMSStyleSpan(style: stroke) ]
+      } else {
+        let stroke = GMSStrokeStyle.solidColor(.clear)
+        stroke.stampStyle = GMSTextureStyle(image: image)
+        spans = [ GMSStyleSpan(style: stroke) ]
+      }
+      polyline.spans = spans
+      polyline.map = mapView
+      // [END maps_ios_map_capabilities]
+    }
 }


### PR DESCRIPTION
Provides new **code samples** for sprite stamped polylines, textured stamped polylines and map capabilities.