### PR TITLE
chore: Add @MainActor annotations for Swift 6 concurrency [Phase 2]

### DIFF
--- a/GoogleMaps-Swift/GoogleMapsSwiftXCFrameworkDemos/Swift/Samples/AnimatedCurrentLocationViewController.swift
+++ b/GoogleMaps-Swift/GoogleMapsSwiftXCFrameworkDemos/Swift/Samples/AnimatedCurrentLocationViewController.swift
@@ -70,7 +70,7 @@ final class AnimatedCurrentLocationViewController: UIViewController {
   }
 }
 
-extension AnimatedCurrentLocationViewController: CLLocationManagerDelegate {
+extension AnimatedCurrentLocationViewController: @MainActor CLLocationManagerDelegate {
   func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
     if locationManager.authorizationStatus == .denied {
       print("Please authorize location services")

--- a/GoogleMaps-Swift/GoogleMapsSwiftXCFrameworkDemos/Swift/Samples/CustomIndoorViewController.swift
+++ b/GoogleMaps-Swift/GoogleMapsSwiftXCFrameworkDemos/Swift/Samples/CustomIndoorViewController.swift
@@ -64,7 +64,7 @@ class CustomIndoorViewController: UIViewController {
 
 }
 
-extension CustomIndoorViewController: GMSIndoorDisplayDelegate {
+extension CustomIndoorViewController: @MainActor GMSIndoorDisplayDelegate {
 
   func didChangeActiveBuilding(_ building: GMSIndoorBuilding?) {
     guard let building = building else {

--- a/GoogleMaps-Swift/GoogleMapsSwiftXCFrameworkDemos/Swift/Samples/DataDrivenStylingBasicViewController.swift
+++ b/GoogleMaps-Swift/GoogleMapsSwiftXCFrameworkDemos/Swift/Samples/DataDrivenStylingBasicViewController.swift
@@ -32,6 +32,7 @@ private struct FeatureLayerConfig {
   let highlightPlaceID: String
 }
 
+@MainActor
 private class SliderControls {
   let view: UIStackView
   let fillColor: UISlider
@@ -39,6 +40,7 @@ private class SliderControls {
   let strokeWidth: UISlider
   let label: UILabel
 
+  @MainActor
   private static func addSliderAndLabel(to parent: UIStackView, text: String, initialValue: Float)
     -> UISlider
   {

--- a/GoogleMaps-Swift/GoogleMapsSwiftXCFrameworkDemos/Swift/Samples/DataDrivenStylingSearchViewController.swift
+++ b/GoogleMaps-Swift/GoogleMapsSwiftXCFrameworkDemos/Swift/Samples/DataDrivenStylingSearchViewController.swift
@@ -50,6 +50,7 @@ private struct PlaceTextSearchResponse: Codable {
   let places: [Place]
 }
 
+@MainActor
 private class PlaceLookupController: NSObject {
   let serial: Int
   let controller: DataDrivenStylingSearchViewController


### PR DESCRIPTION
## Summary
  - Continues Swift 6 concurrency migration by adding `@MainActor` annotations to delegate implementations and UI-related classes
  - Fixes MainActor isolation warnings in 4 view controllers
  - Ensures thread safety for UI operations in delegate methods

  ## Changes Made
  - **AnimatedCurrentLocationViewController**: Added `@MainActor` to `CLLocationManagerDelegate` extension
  - **CustomIndoorViewController**: Added `@MainActor` to `GMSIndoorDisplayDelegate` extension
  - **DataDrivenStylingBasicViewController**: Added `@MainActor` to `SliderControls` class and `addSliderAndLabel` static method
  - **DataDrivenStylingSearchViewController**: Added `@MainActor` to `PlaceLookupController` class

  ## Test Plan
  - [x] Verify no Swift 6 concurrency warnings in modified files
  - [x] Ensure existing functionality remains unchanged
  - [x] Test delegate methods respond correctly to user interactions
  - [x] Confirm UI updates happen on main thread

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-06 at 10 08 50" src="https://github.com/user-attachments/assets/a35a3286-e52a-4dc2-9ad1-d5252b1b87a8" />

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-05-06 at 10 08 56" src="https://github.com/user-attachments/assets/1103ad9c-f813-4da7-b3c2-1628524cbf73" />
